### PR TITLE
Optionally render node with HTML content

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -495,8 +495,20 @@ Tree.createLiEle = function(node, closed) {
   li.appendChild(checkbox);
   const label = document.createElement('span');
   label.classList.add('treejs-label');
-  const text = document.createTextNode(node.text);
-  label.appendChild(text);
+  
+  // Optionally node with HTML if specified (else defaults to textNode)
+  const content =
+      (!!node.html)
+          ? (function (content) {
+              var node = document.createElement('span');
+              node.innerHTML = content;
+
+              return node;
+          })(node.html)
+
+          : document.createTextNode(node.text);
+  
+  label.appendChild(content);
   li.appendChild(label);
   li.nodeId = node.id;
   return li;


### PR DESCRIPTION
Basic support for rendering node with HTML label.

Example:
````
{
    "id": "1-0-1",
    "html": "node-1-0-1 <a href=\"#\">Hello, world!</a>",
},
````

Result:

![image](https://user-images.githubusercontent.com/3855027/82265302-89020880-991b-11ea-9de6-93fc2156f376.png)
