### PR TITLE
Collapse all nodes deeper than the specified closeDepth

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ Tree.prototype.buildTree = function(nodes, depth) {
     nodes.forEach(node => {
       const liEle = Tree.createLiEle(
         node,
-        depth === this.options.closeDepth - 1
+        depth >= this.options.closeDepth - 1
       );
       this.liElementsById[node.id] = liEle;
       let ulEle = null;


### PR DESCRIPTION
Instead of just collapsing the nodes on the exact level it makes more sense to do so in all the levels below it as well