### PR TITLE
Include blank data object in ajax.js defaultOptions

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -5,6 +5,7 @@ export default function(_options) {
     async: true,
     success: null,
     failed: null,
+    data: {},
     'Content-Type': 'application/json; charset=utf-8',
   };
   const options = Object.assign(defaultOptions, _options);


### PR DESCRIPTION
In a GET request, when options.data is null, Object.entries() fails

`Uncaught (in promise) TypeError: Cannot convert undefined or null to object`

Including data:{} in defaultOptions fixes this issue