### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import Tree from '@widgetjs/tree';
   "text": "node-0",
   "attributes": {},
   "children": [],
-  "check": true
+  "checked": true
 }
 ```
 
@@ -65,7 +65,7 @@ import Tree from '@widgetjs/tree';
 | text       | string  | tree node label                     | Required |
 | attributes | object  | custom attributes of the node       | Optional |
 | children   | array   | children of current node            | Optional |
-| check      | boolean | whether the node is selected or not | Optional |
+| checked      | boolean | whether the node is selected or not | Optional |
 
 ### Example
 


### PR DESCRIPTION
I noticed the option "check" does not match the code in "index.js" line 450. Using the component with check does not work, but changing the key to "checked" fixed the issue. So I want to update the docs to prevent more people to having this issue.

Fixes issue #8 